### PR TITLE
Make indentation consistent

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,6 @@
 [flake8]
-ignore = E501,E302
-max-line-length = 119
+ignore = E302
 
 # Explaination of ignored error codes:
-#
-# E501:	line too long (82 > 79 characters)
-# (the max-line-length directive increases line length to 119)
 #
 # E302: expected 2 blank lines, found 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[flake8]
+ignore = E501,E302
+max-line-length = 119
+
+# Explaination of ignored error codes:
+#
+# E501:	line too long (82 > 79 characters)
+# (the max-line-length directive increases line length to 119)
+#
+# E302: expected 2 blank lines, found 0

--- a/swe-pipeline.py
+++ b/swe-pipeline.py
@@ -122,7 +122,9 @@ def process_file(options, filename, tmp_dir, models):
 
     parsed_filename = ""
     if options.parsed:
-        parsed_filename = parse(options, filename, annotated_sentences, tmp_dir)
+        parsed_filename = parse(
+            options, filename, annotated_sentences, tmp_dir
+        )
 
     write_to_output(
         options,
@@ -155,7 +157,10 @@ def run_tagging_and_lemmatization(sentence, models):
     suc_tags_list = models["suc_tagger"].tag(sentence)
 
     if models["lemmatizer"]:
-        lemmas = [models["lemmatizer"].predict(token, tag) for token, tag in zip(sentence, suc_tags_list)]
+        lemmas = [
+            models["lemmatizer"].predict(token, tag)
+            for token, tag in zip(sentence, suc_tags_list)
+        ]
         ud_tags_list = models["ud_tagger"].tag(sentence, lemmas, suc_tags_list)
         if models["suc_ne_tagger"] is not None:
             suc_ne_list = models["suc_ne_tagger"].tag(
@@ -191,7 +196,9 @@ def parse(options, filename, annotated_sentences, tmp_dir):
 
     # Run the parser
     with open(log_filename, "w", encoding="utf-8") as log_file:
-        returncode = Popen(parser_cmdline, stdout=log_file, stderr=log_file).wait()
+        returncode = Popen(
+            parser_cmdline, stdout=log_file, stderr=log_file
+        ).wait()
 
     if returncode:
         sys.exit("Parsing failed! Log file may contain more information: %s" % log_filename)

--- a/swe-pipeline.py
+++ b/swe-pipeline.py
@@ -104,15 +104,11 @@ def process_file(options, filename, tmp_dir, models):
                 ]
 
                 if lemmas and ud_tags_list:
-                    lines = [
-                        "\t".join(line)
-                        for line in zip(sentence, suc_tags_list, ud_tag_list, lemmas)
-                    ]
+                    line_tokens = sentence, suc_tags_list, ud_tag_list, lemmas
                 else:
-                    lines = [
-                        "\t".join(line)
-                        for line in zip(sentence, suc_tags_list)
-                    ]
+                    line_tokens = sentence, suc_tags_list
+
+                lines = ["\t".join(line) for line in zip(*line_tokens)]
 
                 write_to_file(tagged, lines)
 

--- a/swe-pipeline.py
+++ b/swe-pipeline.py
@@ -126,13 +126,12 @@ def process_file(options, filename, tmp_dir, models):
             options, filename, annotated_sentences, tmp_dir
         )
 
-    write_to_output(
-        options,
-        tokenized_filename,
-        tagged_filename,
-        parsed_filename,
-        ner_filename
-    )
+    write_to_output([
+        (options.tokenized, tokenized_filename, options.output_dir),
+        (options.tagged, tagged_filename, options.output_dir),
+        (options.parsed, parsed_filename, options.output_dir),
+        (options.ner, ner_filename, options.output_dir),
+    ])
 
     print("done.", file=sys.stderr)
 
@@ -210,18 +209,10 @@ def write_to_file(file, lines):
         print(line, file=file)
     print(file=file)
 
-def write_to_output(options, tokenized_filename, tagged_filename, parsed_filename, ner_filename):
-    if options.tokenized:
-        shutil.copy(tokenized_filename, options.output_dir)
-
-    if options.tagged:
-        shutil.copy(tagged_filename, options.output_dir)
-
-    if options.parsed:
-        shutil.copy(parsed_filename, options.output_dir)
-
-    if options.ner:
-        shutil.copy(ner_filename, options.output_dir)
+def write_to_output(filename_mapping):
+    for should_copy, filename, output_dir in filename_mapping:
+        if should_copy:
+            shutil.copy(filename, output_dir)
 
 def cleanup(options, tmp_dir):
     if not options.no_delete:

--- a/swe-pipeline.py
+++ b/swe-pipeline.py
@@ -201,7 +201,7 @@ def parse(options, filename, annotated_sentences, tmp_dir):
         ).wait()
 
     if returncode:
-        sys.exit("Parsing failed! Log file may contain more information: %s" % log_filename)
+        sys.exit("Parsing failed! See log file: %s" % log_filename)
 
     return parsed_filename
 


### PR DESCRIPTION
This is a minor fix that makes indentation always use four spaces in swe-pipeline.py. It also adds a setup.py file that increases the max-line-lengths that most text editors use to line-break code automatically.
